### PR TITLE
Fixed class used for Trueskill default_rating.

### DIFF
--- a/skills/trueskill/__init__.py
+++ b/skills/trueskill/__init__.py
@@ -75,7 +75,7 @@ class TrueSkillGameInfo(object):
             raise ValueError("TrueSkillGameInfo arguments must be numeric")
 
     def default_rating(self):
-        return Rating(self.initial_mean, self.initial_stdev)
+        return GaussianRating(self.initial_mean, self.initial_stdev)
 
     @staticmethod
     def ensure_game_info(game_info):


### PR DESCRIPTION
TrueSkillGameInfo.default_rating() attempted to instantiate Rating, which is not imported in the module and doesn't take a stdev argument.